### PR TITLE
fix: WB-876 maj build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -86,7 +86,7 @@ initDev () {
 }
 
 build () {
-  rm -rf build-css
+  rm -rf build-css/
   local extras=$1
   #get skins
   dirs=($(ls -d ./skins/*))


### PR DESCRIPTION
Maj du build.sh pour la suppression du dossier build-css/ avant de faire le build css